### PR TITLE
Switch from Homebrew Formula to Cask

### DIFF
--- a/Casks/wezterm-nightly.rb
+++ b/Casks/wezterm-nightly.rb
@@ -43,6 +43,11 @@ cask "wezterm-nightly" do
       /opt/homebrew/bin/ for M1 Mac.
 
     Removal of them is ensured by 'brew uninstall --cask #{token}'.
+
+    Since there's no version info included in the download URL of the nightly
+    build, NO update will be notified for 'wezterm-nightly' by Homebrew. (Not a
+    problem for non-nightly, regular released 'wezterm'.) To get the nightly
+    update, just run 'brew upgrade --cask wezterm-nightly'.
   EOS
   end
 end

--- a/Casks/wezterm-nightly.rb
+++ b/Casks/wezterm-nightly.rb
@@ -1,0 +1,48 @@
+cask "wezterm-nightly" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-macos-nightly.zip"
+  name "WezTerm"
+  desc "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
+  homepage "https://wezfurlong.org/wezterm/"
+
+  conflicts_with cask: "wez/wezterm/wezterm"
+
+  # Unclear what the minimal OS version is
+  # depends_on macos: ">= :sierra"
+
+  app "WezTerm.app"
+  [
+    "wezterm",
+    "wezterm-gui",
+    "wezterm-mux-server",
+    "strip-ansi-escapes"
+  ].each do |tool|
+    binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
+  end
+
+  preflight do
+    # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
+    staged_subfolder = staged_path.glob(["WezTerm-*", "wezterm-*"]).first
+    if staged_subfolder
+      FileUtils.mv(staged_subfolder/"WezTerm.app", staged_path)
+      FileUtils.rm_rf(staged_subfolder)
+    end
+  end
+
+  zap trash: [
+    "~/.config/wezterm",
+    "~/Library/Saved Application State/com.github.wez.wezterm.savedState",
+  ]
+
+  def caveats; <<~EOS
+    Cask #{token} related executables like 'wezterm', 'wezterm-gui',
+    'wezterm-mux-server', are linked into
+      /usr/local/bin/    for x86 Mac,
+      /opt/homebrew/bin/ for M1 Mac.
+
+    Removal of them is ensured by 'brew uninstall --cask #{token}'.
+  EOS
+  end
+end

--- a/Casks/wezterm-nightly.rb
+++ b/Casks/wezterm-nightly.rb
@@ -32,7 +32,6 @@ cask "wezterm-nightly" do
   end
 
   zap trash: [
-    "~/.config/wezterm",
     "~/Library/Saved Application State/com.github.wez.wezterm.savedState",
   ]
 

--- a/Casks/wezterm.rb
+++ b/Casks/wezterm.rb
@@ -1,0 +1,48 @@
+cask "wezterm" do
+  version "20210502-154244-3f7122cb"
+  sha256 "be8e235d5bf6b2876a993f8c084cd7bfc3cf8121e7aa99038d9209ee87dd9118"
+
+  url "https://github.com/wez/wezterm/releases/download/#{version}/WezTerm-macos-#{version}.zip"
+  name "WezTerm"
+  desc "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
+  homepage "https://wezfurlong.org/wezterm/"
+
+  conflicts_with cask: "wez/wezterm/wezterm-nightly"
+
+  # Unclear what the minimal OS version is
+  # depends_on macos: ">= :sierra"
+
+  app "WezTerm.app"
+  [
+    "wezterm",
+    "wezterm-gui",
+    "wezterm-mux-server",
+    "strip-ansi-escapes"
+  ].each do |tool|
+    binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
+  end
+
+  preflight do
+    # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
+    staged_subfolder = staged_path.glob(["WezTerm-*", "wezterm-*"]).first
+    if staged_subfolder
+      FileUtils.mv(staged_subfolder/"WezTerm.app", staged_path)
+      FileUtils.rm_rf(staged_subfolder)
+    end
+  end
+
+  zap trash: [
+    "~/.config/wezterm",
+    "~/Library/Saved Application State/com.github.wez.wezterm.savedState",
+  ]
+
+  def caveats; <<~EOS
+    Cask #{token} related executables like 'wezterm', 'wezterm-gui',
+    'wezterm-mux-server', are linked into
+      /usr/local/bin/    for x86 Mac,
+      /opt/homebrew/bin/ for M1 Mac.
+
+    Removal of them is ensured by 'brew uninstall --cask #{token}'.
+  EOS
+  end
+end

--- a/Casks/wezterm.rb
+++ b/Casks/wezterm.rb
@@ -32,7 +32,6 @@ cask "wezterm" do
   end
 
   zap trash: [
-    "~/.config/wezterm",
     "~/Library/Saved Application State/com.github.wez.wezterm.savedState",
   ]
 

--- a/Formula/wezterm.rb
+++ b/Formula/wezterm.rb
@@ -6,9 +6,32 @@
 class Wezterm < Formula
   desc "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
   homepage "https://wezfurlong.org/wezterm/"
-  url "https://github.com/wez/wezterm/releases/download/20210502-154244-3f7122cb/WezTerm-macos-20210502-154244-3f7122cb.zip"
-  sha256 "be8e235d5bf6b2876a993f8c084cd7bfc3cf8121e7aa99038d9209ee87dd9118"
+  version "20210522-migration-notice"
+  url "https://github.com/wez/wezterm/releases/download/#{version}/WezTerm-macos-#{version}.zip"
+  sha256 :no_check
   head "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-macos-nightly.zip"
+
+  disable! date: "2021-05-22", because: <<~EOS
+    is migrated from
+    current Formula to Casks 'wezterm' and 'wezterm-nightly'. With the new Casks,
+    the WezTerm.app will be put into /Applications/ automatically.
+
+    You should migrate to the new Cask right now.
+    If you have formula 'wezterm' installed, uninstall it first,
+      brew uninstall --formula wezterm
+      rm -rf /Applications/WezTerm.app
+    Then install WezTerm from the new cask 'wezterm',
+      brew install --cask wezterm
+    or 'wezterm-nightly' for nightly build,
+      brew install --cask wezterm-nightly
+
+    This formula may remain in the repo for a while to notice users migrate to the cask,
+    which results a name conflict between the formula 'wezterm' and the cask 'wezterm'.
+    Please pass '--cask' explicitly when doing 'wezterm' related 'brew' command, e.g.
+      brew upgrade --cask wezterm
+
+    Sorry about the trouble for you guys
+  EOS
 
   def install
     prefix.install "WezTerm.app"


### PR DESCRIPTION
Propose to switch to Cask, which install the app into `/Applications` automatically for the user.

The 1st commit adds two Casks `wezterm` and `wezterm-nightly`.

The 2nd commit adds a `disable!` error to the old formula, and triggers a fake upgrade. When users install, or upgrade from the old formula, an `Error` pops up with guides for migration to the Casks. Here's what's the output,

```plaintext
❯ brew upgrade wezterm
Warning: Treating wezterm as a formula. For the cask, use wez/wezterm/wezterm
==> Upgrading 1 outdated package:
wez/wezterm/wezterm 20210522-migration-notice
==> Upgrading wez/wezterm/wezterm -> 20210522-migration-notice
Error: wez/wezterm/wezterm has been disabled because it is migrated from
current Formula to Casks 'wezterm' and 'wezterm-nightly'. With the new Casks,
the WezTerm.app will be put into /Applications/ automatically.

You should migrate to the new Cask right now.
If you have formula 'wezterm' installed, uninstall it first,
  brew uninstall --formula wezterm
  rm -rf /Applications/WezTerm.app
Then install WezTerm from the new cask 'wezterm',
  brew install --cask wezterm
or 'wezterm-nightly' for nightly build,
  brew install --cask wezterm-nightly

This formula may remain in the repo for a while to notice users migrate to the cask,
which results a name conflict between the formula 'wezterm' and the cask 'wezterm'.
Please pass '--cask' explicitly when doing an upgrade,
  brew upgrade --cask wezterm

Sorry about the trouble for you guys
!
```

The same `Error` pops up when doing `brew install wezterm`.