### PR TITLE
Update README with working installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 A Homebrew Tap for installing [wezterm](http://wezfurlong.org/wezterm/) for homebrew users.
 
 ```bash
-$ brew tap wez/wezterm
-$ brew install wezterm
+brew tap wez/wezterm
+brew install --cask wez/wezterm/wezterm
 ```


### PR DESCRIPTION
When trying to install wezterm I had 2 issues;

 1. Copy-pasting the command did not work, as it also copied the `$` prepending the commands (which was annoying)
 2. The install command did not work for me, I ended up using the one in the (wezterm documentation)[https://wezfurlong.org/wezterm/install/macos.html#homebrew]

```log
❯ brew tap wez/wezterm
==> Tapping wez/wezterm
Cloning into '/usr/local/Homebrew/Library/Taps/wez/homebrew-wezterm'...
remote: Enumerating objects: 129, done.
remote: Counting objects: 100% (129/129), done.
remote: Compressing objects: 100% (84/84), done.
remote: Total 129 (delta 32), reused 106 (delta 25), pack-reused 0
Receiving objects: 100% (129/129), 19.05 KiB | 368.00 KiB/s, done.
Resolving deltas: 100% (32/32), done.
Tapped 2 casks and 1 formula (16 files, 33.7KB).
❯ brew install wezterm
Warning: Treating wezterm as a formula. For the cask, use homebrew/cask/wezterm
Error: wez/wezterm/wezterm has been disabled because it is migrated from
current Formula to Casks 'wezterm' and 'wezterm-nightly'. With the new Casks,
the WezTerm.app will be put into /Applications/ automatically.

You should migrate to the new Cask right now.
If you have formula 'wezterm' installed, uninstall it first,
  brew uninstall --formula wezterm
  rm -rf /Applications/WezTerm.app
Then install WezTerm from the new cask 'wezterm',
  brew install --cask wezterm --no-quarantine
or 'wezterm-nightly' for nightly build,
  brew install --cask wezterm-nightly --no-quarantine

This formula may remain in the repo for a while to notice users migrate to the cask,
which results a name conflict between the formula 'wezterm' and the cask 'wezterm'.
Please pass '--cask' explicitly when doing 'wezterm' related 'brew' command, e.g.
  brew upgrade --cask wezterm --no-quarantine

Sorry about the trouble for you guys
!
```

```log
❯ brew install --cask wez/wezterm/wezterm
==> Caveats
Cask wezterm related executables like 'wezterm', 'wezterm-gui',
'wezterm-mux-server', are linked into
  /usr/local/bin/    for x86 Mac,
  /opt/homebrew/bin/ for M1 Mac.

Removal of them is ensured by 'brew uninstall --cask wezterm'.

==> Downloading https://github.com/wez/wezterm/releases/download/20220319-142410-0fcdea07/WezTerm-macos-20220319-142410-0fcdea07.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/120568143/817eac89-dd96-4b59-b85a-77306dc3da1a?X-Amz-Algorithm
######################################################################## 100.0%
==> Installing Cask wezterm
==> Moving App 'WezTerm.app' to '/Applications/WezTerm.app'
==> Linking Binary 'wezterm' to '/usr/local/bin/wezterm'
==> Linking Binary 'wezterm-gui' to '/usr/local/bin/wezterm-gui'
==> Linking Binary 'wezterm-mux-server' to '/usr/local/bin/wezterm-mux-server'
==> Linking Binary 'strip-ansi-escapes' to '/usr/local/bin/strip-ansi-escapes'
🍺  wezterm was successfully installed!
```