### PR TITLE
feat: added a way to upgrade wezterm-nightly 

### DIFF
--- a/Casks/wezterm-nightly.rb
+++ b/Casks/wezterm-nightly.rb
@@ -24,7 +24,7 @@ cask "wezterm-nightly" do
 
       year = match[4]
       month_idx = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"].index {|month| month == match[3].downcase}
-      month = (month ? month + 1 : 0).to_s.rjust(2,"0")
+      month = (month_idx ? month_idx + 1 : 0).to_s.rjust(2,"0")
       day = match[2].rjust(2, '0')
       hour = match[5].rjust(2, '0')
       minute = match[6].rjust(2, '0')

--- a/Casks/wezterm-nightly.rb
+++ b/Casks/wezterm-nightly.rb
@@ -11,6 +11,27 @@ cask "wezterm-nightly" do
 
   # Unclear what the minimal OS version is
   # depends_on macos: ">= :sierra"
+  
+  livecheck do 
+    url "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-macos-nightly.zip"
+    strategy :header_match do |headers|
+      # matches last-modified header syntax
+      regex = /(\w{3}, )?(\d{1,2}) (\w{3}) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT/
+      match = headers["last-modified"].match(regex)
+      if match.nil?
+        match = headers["x-ms-creation-time"].match(regex)
+      end
+
+      year = match[4]
+      month_idx = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"].index {|month| month == match[3].downcase}
+      month = (month ? month + 1 : 0).to_s.rjust(2,"0")
+      day = match[2].rjust(2, '0')
+      hour = match[5].rjust(2, '0')
+      minute = match[6].rjust(2, '0')
+      second = match[7].rjust(2, '0')
+      "#{year}#{month}#{day}#{hour}#{minute}#{second}"
+    end
+  end
 
   app "WezTerm.app"
   [
@@ -42,12 +63,6 @@ cask "wezterm-nightly" do
       /opt/homebrew/bin/ for M1 Mac.
 
     Removal of them is ensured by 'brew uninstall --cask #{token}'.
-
-    Since there's no version info included in the download URL of the nightly
-    build, NO update will be notified for 'wezterm-nightly' by Homebrew. (Not a
-    problem for non-nightly, regular released 'wezterm'.) To get the nightly
-    update, just run 
-    'brew upgrade --cask wezterm-nightly --no-quarantine --greedy-latest'.
   EOS
   end
 end


### PR DESCRIPTION
The fact that you had to use `brew upgrade --cask wezterm-nightly --no-quarantine --greedy-latest` to upgrade wezterm-nightly was annoying me so I started looking for a solution.  
Seeing that I'm not the only one annoyed by this (see #8 ) I've created this pull request which fixes the need for additional flags.  

Apparently brew formulas use a livecheck to check whether an upgrade is done or not.  
I've noticed that github sets the last-modified header to the date and time the file was uploaded and brew has a livecheck which is able to access http headers.  
I'm using the date and time to construct a pseudo version which is just `<year><month><day><hour><minute><second>` without the < >.  
Yesterday I've setup my own homebrew repo to test if this would work and it does.  
I've been able to upgrade nightly like any other cask.  

I'll open a pull request on the official homebrew-cask repo as well although I'm not sure if it'll get accepted because the livecheck I've used states:

> This class is part of a private API. This class may only be used in the [Homebrew/brew](https://github.com/Homebrew/brew) repository. Third parties should avoid using this class if possible, as it may be removed or changed without warning.  

This is the reason I'm opening the pull request here first.  

That being said I've seen other casks in the official repo which also use this livecheck strategy. 